### PR TITLE
Bugfix: Don't attempt to generate a damage preview when selection type is SelectTargetNoDamage

### DIFF
--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -934,7 +934,7 @@ namespace Handelabra.Sentinels.UnitTest
                                     selectCardDecision.SelectedCard = selectCardDecision.Choices.FirstOrDefault();
                                 }
 
-                                if (selectCardDecision is SelectTargetDecision && this.ShowDamagePreview && selectCardDecision.SelectedCard != null)
+                                if (selectCardDecision is SelectTargetDecision && this.ShowDamagePreview && selectCardDecision.SelectedCard != null && selectCardDecision.SelectionType != SelectionType.SelectTargetNoDamage)
                                 {
                                     SelectTargetDecision selectTarget = selectCardDecision as SelectTargetDecision;
                                     Console.WriteLine("--- BEGIN PREVIEW ---");


### PR DESCRIPTION
What happens: When a unit test makes a decision with the type `SelectionType.SelectTargetNoDamage`, the test will make the appropriate selection, but then attempt to generate a damage preview. This will fail if no damage is associated with the action; given the name of the SelectionType, this seems like it might just be an issue with the test base.

This is the test I wrote that triggered the situation (which is based on CaseFiles). Without the fix, the test fails on Cue, but passes on the other cards being put into play.

```csharp
        [TestCase("Bank")]
        [TestCase("Cue")]
        [TestCase("Kiss")]
        [TestCase("Pocket")]
        [TestCase("Scratch")]
        public void Tucker_Moondancer_Innate_PlaysTrickShot(string trickShotInHand)
        {
            SetupGameController("BaronBlade", MoondancerTuckerCharacter, "Legacy", "Bunker", "TheWraith", "Megalopolis");
            StartGame();

            DestroyCard("MobileDefensePlatform");
            DiscardAllCards(tucker); // No other trick-shots in hand
            Card trickShot = PutInHand(trickShotInHand);

            GoToUsePowerPhase(tucker);
            UsePower(tucker);

            AssertNumberOfCardsInHand(tucker, trickShotInHand == Bank ? 1 : 0);
            AssertInTrash(trickShot);
        }
```

Here is a code snippet of the offending helper function that causes the situation (which is, itself, a re-hash of SelectTargetAndIncreaseNextDamage). The exception occurs when calling the method `SelectTargetAndStoreResults()`

```csharp
    public static IEnumerator SelectTargetAndIncreaseNextDamageTaken(this GameController gameController, HeroTurnTakerController hero, int amountToIncrease, int numberOfUses = 1, LinqCardCriteria additionalCriteria = null, CardSource cardSource = null)
        {
            List<SelectTargetDecision> selectedTargetsResult = new List<SelectTargetDecision>();

            if (additionalCriteria == null)
            {
                additionalCriteria = new LinqCardCriteria();
            }

            IEnumerator routine = gameController.SelectTargetAndStoreResults(hero, gameController.FindTargetsInPlay(null, null), selectedTargetsResult,
                optional: false, allowAutoDecide: false, additionalCriteria: additionalCriteria.Criteria, selectionType: SelectionType.SelectTargetNoDamage,
                cardSource: cardSource);

            if (gameController.UseUnityCoroutines)
            {
                yield return gameController.StartCoroutine(routine);
            }
            else
            {
                gameController.ExhaustCoroutine(routine);
            }

            SelectTargetDecision selectTargetDecision = selectedTargetsResult.FirstOrDefault();

            if (selectTargetDecision != null && selectTargetDecision.SelectedCard != null)
            {
                Card card = selectTargetDecision.SelectedCard;

                IncreaseDamageStatusEffect increaseDamageStatusEffect = new IncreaseDamageStatusEffect(amountToIncrease);
                increaseDamageStatusEffect.TargetCriteria.IsSpecificCard = card;
                increaseDamageStatusEffect.NumberOfUses = numberOfUses;

                StatusEffect statusEffect = increaseDamageStatusEffect;
                statusEffect.Identifier = $"IncreaseNextDamageDealtTo{card?.ToString()}ThanksTo{cardSource.Card.Identifier}";

                routine = gameController.AddStatusEffect(increaseDamageStatusEffect, true, cardSource);

                if (gameController.UseUnityCoroutines)
                {
                    yield return gameController.StartCoroutine(routine);
                }
                else
                {
                    gameController.ExhaustCoroutine(routine);
                }
            }
        }
```

Alternatively, if you think there is a better selection type for this method (apart from Custom), I'm all ears. :)