### PR TITLE
Random game enhancements

### DIFF
--- a/MyModTest/MyRandomTest.cs
+++ b/MyModTest/MyRandomTest.cs
@@ -48,5 +48,33 @@ namespace MyModTest
                 useHeroes: new List<string> { "Workshopping.MigrantCoder" });
             RunGame(gameController);
         }
+
+        [Test]
+        public void TestRandomGameAgainstBaronJeremy()
+        {
+            GameController gameController = SetupRandomGameController(false,
+                DeckDefinition.AvailableHeroes.Concat(ModHeroes),
+                DeckDefinition.AvailableVillains.Concat(ModVillains),
+                DeckDefinition.AvailableEnvironments.Concat(ModEnvironments),
+                overrideVillain: "BaronBlade",
+                overrideVariants: new Dictionary<string, string> { { "BaronBlade", "BaronJeremyCharacter" } });
+            RunGame(gameController);
+        }
+
+        [Test]
+        public void TestRandomGameAgainstCustomVariantHeroes()
+        {
+            GameController gameController = SetupRandomGameController(false,
+                DeckDefinition.AvailableHeroes.Concat(ModHeroes),
+                DeckDefinition.AvailableVillains.Concat(ModVillains),
+                DeckDefinition.AvailableEnvironments.Concat(ModEnvironments),
+                useHeroes: new List<string> { "SkyScraper", "TheSentinels" },
+                overrideVariants: new Dictionary<string, string>
+                    {
+                        { "SkyScraper", "CentristSkyScraperNormalCharacter" },
+                        { "TheSentinels", "TheSerpentinelsInstructions" }
+                    });
+            RunGame(gameController);
+        }
     }
 }

--- a/MyModTest/RandomGameTest.cs
+++ b/MyModTest/RandomGameTest.cs
@@ -99,6 +99,12 @@ namespace Handelabra.Sentinels.UnitTest
                     heroName = heroInfo.FirstOrDefault().Value;
                 }
 
+                if (overrideVariants.ContainsKey(hero))
+                {
+                    var heroInfo = GetSpecificVariant(hero, overrideVariants[hero], promoIdentifiers);
+                    heroName = heroInfo.Values.FirstOrDefault();
+                }
+
                 Console.WriteLine(heroName + " joins the team!");
                 heroes.Add(hero);
                 heroesLeft.Remove(hero);
@@ -157,11 +163,11 @@ namespace Handelabra.Sentinels.UnitTest
             return GetRandomVariant(villain, promoIdentifiers);
         }
 
-                private Dictionary<string, string> GetRandomVariant(string identifier, Dictionary<string, string> promoIdentifiers)
+        private Dictionary<string, string> GetRandomVariant(string identifier, Dictionary<string, string> promoIdentifiers)
         {
             var definition = DeckDefinitionCache.GetDeckDefinition(identifier);
             var promosToCheck = new List<CardDefinition>();
-            promosToCheck.AddRange(definition.PromoCardDefinitions);
+            promosToCheck.AddRange(definition.PromoCardDefinitions.Where((CardDefinition cd) => cd.Identifier.Contains(definition.Identifier)));
             promosToCheck.AddRange(ModHelper.GetAllPromoDefinitions().Where((CardDefinition cd) => cd.Identifier.Contains(definition.Identifier)));
 
             var name = definition.Name;
@@ -172,8 +178,21 @@ namespace Handelabra.Sentinels.UnitTest
             if (promoIndex > 0)
             {
                 var promo = promosToCheck.ElementAt(promoIndex - 1);
-                promoIdentifiers[identifier] = promo.PromoIdentifier;
                 name = promo.PromoTitle;
+                string ns = definition.Namespace != promo.Namespace ? $"{promo.Namespace}." : "";
+
+                if (identifier != "TheSentinels")
+                {
+                    promoIdentifiers[identifier] = ns + promo.PromoIdentifier;
+                }
+                else
+                {
+                    promoIdentifiers["TheSentinelsInstructions"] = ns + promo.PromoIdentifier;
+                    promoIdentifiers["DrMedicoCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(0);
+                    promoIdentifiers["MainstayCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(1);
+                    promoIdentifiers["TheIdealistCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(2);
+                    promoIdentifiers["WritheCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(3);
+                }
             }
 
             return new Dictionary<string, string> { { identifier, name } };
@@ -183,7 +202,7 @@ namespace Handelabra.Sentinels.UnitTest
         {
             var definition = DeckDefinitionCache.GetDeckDefinition(identifier);
             var promosToCheck = new List<CardDefinition>();
-            promosToCheck.AddRange(definition.PromoCardDefinitions);
+            promosToCheck.AddRange(definition.PromoCardDefinitions.Where((CardDefinition cd) => cd.Identifier.Contains(definition.Identifier)));
             promosToCheck.AddRange(ModHelper.GetAllPromoDefinitions().Where((CardDefinition cd) => cd.Identifier.Contains(definition.Identifier)));
 
             var name = definition.Name;
@@ -197,8 +216,21 @@ namespace Handelabra.Sentinels.UnitTest
                 Assert.Fail($"ERROR: Cannot find variant {promoIdentifier} for {identifier}.");
             }
 
-            promoIdentifiers[identifier] = promo.PromoIdentifier;
             name = promo.PromoTitle;
+            string ns = definition.Namespace != promo.Namespace ? $"{promo.Namespace}." : "";
+
+            if (identifier != "TheSentinels")
+            {
+                promoIdentifiers[identifier] = ns + promo.PromoIdentifier;
+            }
+            else
+            {
+                promoIdentifiers["TheSentinelsInstructions"] = ns + promo.PromoIdentifier;
+                promoIdentifiers["DrMedicoCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(0);
+                promoIdentifiers["MainstayCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(1);
+                promoIdentifiers["TheIdealistCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(2);
+                promoIdentifiers["WritheCharacter"] = ns + promo.AssociatedPromoIdentifiers.ElementAt(3);
+            }
 
             return new Dictionary<string, string> { { identifier, name } };
         }


### PR DESCRIPTION
[joke]Okay, maybe I felt bad about a one-line fix being my only contribution to the repo, so here's something a little more substantial... [/joke]

I really like the random game tests, and while adding them to my project, I found a few things I wanted that they didn't support out of the box. Felt neighborly to add them back to the source that inspired them.

List of enhancements:
* Setting `overrideVillain` allows the game to set the villain you'll face in the same way you can set `overrideEnvironment`. If the villain has a variant, it'll pick one at random.
* Select mod variants for heroes/villains in addition to variants from the deck definition
* Specify which variant to use for a hero/villain through `overrideVariants`. If not specified, the variant is chosen at random. (This is useful for someone like Ruduen, who might not want to choose which heroes get selected for a test but default to one of his fanverse variants. Also useful for testing hero teams)
* `useHeroes` uses a random order and selects a random variant for the hero. It will still put them at the front of the team, but if I select 'Legacy, Wraith' as two heroes, Wraith may sometimes appear first. You can turn this off with the flag `randomizeUseHeroes`
* Fix loading variants for TheSentinels. It's kinda hacky, and right now it only supports all variants from the same team, but it works. Open for feedback here!