### PR TITLE
Target .NET 3.5 for console and test projects

### DIFF
--- a/MyModConsole/MyModConsole.csproj
+++ b/MyModConsole/MyModConsole.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -31,7 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Troschuetz.Random">
-      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net472\Troschuetz.Random.dll</HintPath>
+      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net35\Troschuetz.Random.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/MyModConsole/packages.config
+++ b/MyModConsole/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net472" requireReinstallation="true" />
+  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net35" />
 </packages>

--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -4914,7 +4914,7 @@ namespace Handelabra.Sentinels.UnitTest
                 {
                     var dllpath = System.Reflection.Assembly.GetExecutingAssembly().CodeBase;
                     path = Path.GetDirectoryName(dllpath.Replace("file://", "")).Replace("\\D:", "D:").Replace("\\C:", "C:");
-                    path = Path.Combine(path, "..", "..", "DataFiles", name);
+                    path = new string[] { path, "..", "..", "DataFiles", name }.Aggregate((x, y) => Path.Combine(x, y));
                 }
                 else if (addTempPath)
                 {
@@ -4951,7 +4951,7 @@ namespace Handelabra.Sentinels.UnitTest
 
                 var dllpath = System.Reflection.Assembly.GetExecutingAssembly().CodeBase;
                 var path = Path.GetDirectoryName(dllpath.Replace("file://", "")).Replace("\\D:", "D:").Replace("\\C:", "C:");
-                path = Path.Combine(path, "..", "..", "DataFiles", name);
+                path = new string[] { path, "..", "..", "DataFiles", name }.Aggregate((x, y) => Path.Combine(x, y));
                 var savedGame = LoadGamePath(path);
 
                 if (savedGame != null)

--- a/MyModTest/MyModTest.csproj
+++ b/MyModTest/MyModTest.csproj
@@ -6,6 +6,7 @@
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -33,7 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.12.0\lib\net35\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="EngineCommon">
       <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\Sentinels of the Multiverse\Sentinels.app\Contents\Resources\Data\Managed\EngineCommon.dll</HintPath>
@@ -42,7 +43,7 @@
       <HintPath>..\..\Handelabra\SentinelsEngine\SentinelsEngine\bin\Debug\SentinelsEngine.dll</HintPath>
     </Reference>
     <Reference Include="Troschuetz.Random">
-      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net40\Troschuetz.Random.dll</HintPath>
+      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net35\Troschuetz.Random.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MyModTest/packages.config
+++ b/MyModTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.12.0" targetFramework="net472" requireReinstallation="true" />
-  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net40" />
-  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net40" />
+  <package id="NUnit" version="3.12.0" targetFramework="net35" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net35" />
+  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Original blurb from the Discord:

```
Microsoft released Visual Studio 2022 about a month ago. I've started playing around with it since it's something
work wants us to start using. The main takeaway w.r.t. Sentinels mod development is that you can no longer install
versions of the .net framework/sdk <= 4.5.2 other than 3.5. (Also, by default, it only installs .net 6.0)

This is fine for the library itself, but using the workshop mod as an example, the Console + Testing libraries do not work 
out of the box because they target 4.0. I believe targeting 3.5 or 4.8 for both projects works, but I haven't done a bunch
of testing on either (I jumped my personal projects to 6-- apart from the json serialization needing rewritten for
loading/saving games and user preferences, everything else works!). Both of which have LTS up to at least 2028, so
you should be safe to pin the non-library projects to those.

tl;dr - If people don't read the instructions and see 'oh, I need to install Visual Studio' and install 2022, they may
have some hurdles getting the projects working initially.
```

I went with 3.5 so it aligns with the rest of the project; Visual Studio 2022 includes 4.8 if you install the .net build environment, so that would be easy enough to target higher instead. 