### PR TITLE
Random game enhancements

### DIFF
--- a/MyModTest/MyRandomTest.cs
+++ b/MyModTest/MyRandomTest.cs
@@ -48,5 +48,33 @@ namespace MyModTest
                 useHeroes: new List<string> { "Workshopping.MigrantCoder" });
             RunGame(gameController);
         }
+
+        [Test]
+        public void TestRandomGameAgainstBaronJeremy()
+        {
+            GameController gameController = SetupRandomGameController(false,
+                DeckDefinition.AvailableHeroes.Concat(ModHeroes),
+                DeckDefinition.AvailableVillains.Concat(ModVillains),
+                DeckDefinition.AvailableEnvironments.Concat(ModEnvironments),
+                overrideVillain: "BaronBlade",
+                overrideVariants: new Dictionary<string, string> { { "BaronBlade", "BaronJeremyCharacter" } });
+            RunGame(gameController);
+        }
+
+        [Test]
+        public void TestRandomGameAgainstCustomVariantHeroes()
+        {
+            GameController gameController = SetupRandomGameController(false,
+                DeckDefinition.AvailableHeroes.Concat(ModHeroes),
+                DeckDefinition.AvailableVillains.Concat(ModVillains),
+                DeckDefinition.AvailableEnvironments.Concat(ModEnvironments),
+                useHeroes: new List<string> { "SkyScraper", "TheSentinels" },
+                overrideVariants: new Dictionary<string, string>
+                    {
+                        { "SkyScraper", "CentristSkyScraperNormalCharacter" },
+                        { "TheSentinels", "TheSerpentinelsInstructions" }
+                    });
+            RunGame(gameController);
+        }
     }
 }

--- a/MyModTest/RandomGameTest.cs
+++ b/MyModTest/RandomGameTest.cs
@@ -684,114 +684,114 @@ namespace Handelabra.Sentinels.UnitTest
         }
 
         // Example test implementations follow
-        /*
-                [Test]
-                public void TestRandomGameToCompletion()
+/*
+        [Test]
+        public void TestRandomGameToCompletion()
+        {
+            //for (int i = 0; i < 200; i++)
+            {
+                GameController gameController = SetupRandomGameController(false);
+                RunGame(gameController);
+            }
+        }
+
+        [Test]
+        public void TestSomewhatReasonableGameToCompletion()
+        {
+            GameController gameController = SetupRandomGameController(true);
+            RunGame(gameController);
+        }
+
+        [Test]
+        public void TestSkyScraper()
+        {
+            //for (int i = 0; i < 10; i++)
+            {
+                GameController gameController = SetupRandomGameController(false, useHeroes: new List<string> { "SkyScraper" });
+                RunGame(gameController);
+            }
+        }
+
+        [Test]
+        public void TestTachyon_SupersonicResponse()
+        {
+            //for (int i = 0; i < 1000; i++)
+            {
+                SetupRandomGameController(true, useHeroes: new List<string> { "Tachyon" });
+                PreferredCardsToPlay = new string[] { "SupersonicResponse", "FleetOfFoot", "HUDGoggles", "PushingTheLimits" };
+                RunGame(this.GameController);
+            }
+        }
+
+        [Test]
+        public void TestCelestialTribunal()
+        {
+            //for (int i = 0; i < 10; i++)
+            {
+                GameController gameController = SetupRandomGameController(true, overrideEnvironment:"TheCelestialTribunal");
+                RunGame(gameController);
+            }
+        }
+
+        [Test]
+        public void TestRaVersusTheEnnead()
+        {
+            GameController gameController = SetupGameController(new string[] { "TheEnnead", "Ra", "Legacy", "TheWraith", "TombOfAnubis" });
+            gameController.OnMakeDecisions -= MakeDecisions;
+            gameController.OnMakeDecisions += MakeSomewhatReasonableDecisions;
+
+            bool expectNemesis = false;
+            bool nemesisApplied = false;
+            gameController.OnWillPerformAction += action =>
+            {
+                // If it is a deal damage action between the Ennead and Ra, make sure there is some nemesis damage going on.
+                if (action is DealDamageAction)
                 {
-                    //for (int i = 0; i < 200; i++)
+                    var dd = action as DealDamageAction;
+                    if (IsRaVersusTheEnnead(dd))
                     {
-                        GameController gameController = SetupRandomGameController(false);
-                        RunGame(gameController);
+                        // We expect to see some nemesis damage before the end.
+                        expectNemesis = true;
+                    }
+                }
+                else if (action is IncreaseDamageAction)
+                {
+                    var increase = action as IncreaseDamageAction;
+                    if (increase.IsNemesisEffect)
+                    {
+                        nemesisApplied = true;
                     }
                 }
 
-                [Test]
-                public void TestSomewhatReasonableGameToCompletion()
-                {
-                    GameController gameController = SetupRandomGameController(true);
-                    RunGame(gameController);
-                }
+                return DoNothing();
+            };
 
-                [Test]
-                public void TestSkyScraper()
+            gameController.OnDidPerformAction += action =>
+            {
+                // If we expected nemesis, assert that it was applied.
+                if (action is DealDamageAction && expectNemesis)
                 {
-                    //for (int i = 0; i < 10; i++)
+                    var dd = action as DealDamageAction;
+                    if (IsRaVersusTheEnnead(dd) && dd.DidDealDamage)
                     {
-                        GameController gameController = SetupRandomGameController(false, useHeroes: new List<string> { "SkyScraper" });
-                        RunGame(gameController);
+                        Assert.IsTrue(nemesisApplied, "Damage was dealt from " + dd.DamageSource.TitleOrName + " and " + dd.Target.Title + ", but nemesis increase was not applied.");
                     }
+
+                    expectNemesis = false;
+                    nemesisApplied = false;
                 }
 
-                [Test]
-                public void TestTachyon_SupersonicResponse()
-                {
-                    //for (int i = 0; i < 1000; i++)
-                    {
-                        SetupRandomGameController(true, useHeroes: new List<string> { "Tachyon" });
-                        PreferredCardsToPlay = new string[] { "SupersonicResponse", "FleetOfFoot", "HUDGoggles", "PushingTheLimits" };
-                        RunGame(this.GameController);
-                    }
-                }
+                return DoNothing();
+            };
 
-                [Test]
-                public void TestCelestialTribunal()
-                {
-                    //for (int i = 0; i < 10; i++)
-                    {
-                        GameController gameController = SetupRandomGameController(true, overrideEnvironment:"TheCelestialTribunal");
-                        RunGame(gameController);
-                    }
-                }
+            RunGame(gameController);
+        }
 
-                [Test]
-                public void TestRaVersusTheEnnead()
-                {
-                    GameController gameController = SetupGameController(new string[] { "TheEnnead", "Ra", "Legacy", "TheWraith", "TombOfAnubis" });
-                    gameController.OnMakeDecisions -= MakeDecisions;
-                    gameController.OnMakeDecisions += MakeSomewhatReasonableDecisions;
-
-                    bool expectNemesis = false;
-                    bool nemesisApplied = false;
-                    gameController.OnWillPerformAction += action =>
-                    {
-                        // If it is a deal damage action between the Ennead and Ra, make sure there is some nemesis damage going on.
-                        if (action is DealDamageAction)
-                        {
-                            var dd = action as DealDamageAction;
-                            if (IsRaVersusTheEnnead(dd))
-                            {
-                                // We expect to see some nemesis damage before the end.
-                                expectNemesis = true;
-                            }
-                        }
-                        else if (action is IncreaseDamageAction)
-                        {
-                            var increase = action as IncreaseDamageAction;
-                            if (increase.IsNemesisEffect)
-                            {
-                                nemesisApplied = true;
-                            }
-                        }
-
-                        return DoNothing();
-                    };
-
-                    gameController.OnDidPerformAction += action =>
-                    {
-                        // If we expected nemesis, assert that it was applied.
-                        if (action is DealDamageAction && expectNemesis)
-                        {
-                            var dd = action as DealDamageAction;
-                            if (IsRaVersusTheEnnead(dd) && dd.DidDealDamage)
-                            {
-                                Assert.IsTrue(nemesisApplied, "Damage was dealt from " + dd.DamageSource.TitleOrName + " and " + dd.Target.Title + ", but nemesis increase was not applied.");
-                            }
-
-                            expectNemesis = false;
-                            nemesisApplied = false;
-                        }
-
-                        return DoNothing();
-                    };
-
-                    RunGame(gameController);
-                }
-
-                private bool IsRaVersusTheEnnead(DealDamageAction dd)
-                {
-                    return dd.DamageSource.IsCard && (dd.DamageSource.Card.Identifier == "RaCharacter" && dd.Target.Owner.Identifier == "TheEnnead")
-                        || (dd.DamageSource.Card.Owner.Identifier == "TheEnnead" && dd.Target.Identifier == "RaCharacter");
-                }
-        */
+        private bool IsRaVersusTheEnnead(DealDamageAction dd)
+        {
+            return dd.DamageSource.IsCard && (dd.DamageSource.Card.Identifier == "RaCharacter" && dd.Target.Owner.Identifier == "TheEnnead")
+                || (dd.DamageSource.Card.Owner.Identifier == "TheEnnead" && dd.Target.Identifier == "RaCharacter");
+        }
+*/
     }
 }


### PR DESCRIPTION
Originally #7 , but I closed the fork which made it impossible to update the PR. Here's the same PR with the requested adjustments.

I really like the random game tests, and while adding them to my project, I found a few things I wanted that they didn't support out of the box. Felt neighborly to add them back to the source that inspired them.

List of enhancements:

Setting overrideVillain allows the game to set the villain you'll face in the same way you can set overrideEnvironment. If the villain has a variant, it'll pick one at random.
Select mod variants for heroes/villains in addition to variants from the deck definition
Specify which variant to use for a hero/villain through overrideVariants. If not specified, the variant is chosen at random. (This is useful for someone like Ruduen, who might not want to choose which heroes get selected for a test but default to one of his fanverse variants. Also useful for testing hero teams)
useHeroes uses a random order and selects a random variant for the hero. It will still put them at the front of the team, but if I select 'Legacy, Wraith' as two heroes, Wraith may sometimes appear first. You can turn this off with the flag randomizeUseHeroes
Fix loading variants for TheSentinels. It's kinda hacky, and right now it only supports all variants from the same team, but it works. Open for feedback here!