### PR TITLE
Replace RNG lib with a non-deprecated equivalent

### DIFF
--- a/MyModConsole/MyModConsole.csproj
+++ b/MyModConsole/MyModConsole.csproj
@@ -30,10 +30,10 @@
     <ExternalConsole>true</ExternalConsole>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Troschuetz.Random">
-      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net35\Troschuetz.Random.dll</HintPath>
+    <Reference Include="MathNet.Numerics, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="EngineCommon">

--- a/MyModConsole/Program.cs
+++ b/MyModConsole/Program.cs
@@ -11,8 +11,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using Troschuetz.Random;
-using Troschuetz.Random.Generators;
+using MathNet.Numerics.Random;
 using Handelabra;
 using Boomlagoon.JSON;
 using System.Xml.XPath;
@@ -191,7 +190,7 @@ namespace Handelabra.MyModConsole // this has to be this way to work around an E
 
             Dictionary<string, string> promoIdentifiers = new Dictionary<string, string>();
 
-            IGenerator rng = new MT19937Generator();
+            RandomSource rng = new MersenneTwister();
             GameMode gameMode = GameMode.Classic;
 
             string input = GetInput("Do you want to try a random scenario? (y/n)");

--- a/MyModConsole/packages.config
+++ b/MyModConsole/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net35" requireReinstallation="true" />
+  <package id="MathNet.Numerics" version="5.0.0" targetFramework="net48" />
 </packages>

--- a/MyModTest/MyModTest.csproj
+++ b/MyModTest/MyModTest.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <Import Project="..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
     <NuGetPackageImportStamp>
@@ -32,13 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MathNet.Numerics, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Troschuetz.Random">
-      <HintPath>..\packages\Troschuetz.Random.5.0.1\lib\net472\Troschuetz.Random.dll</HintPath>
-    </Reference>
     <Reference Include="EngineCommon">
       <HintPath>..\..\..\..\Library\Application Support\Steam\steamapps\common\Sentinels of the Multiverse\Sentinels.app\Contents\Resources\Data\Managed\EngineCommon.dll</HintPath>
     </Reference>

--- a/MyModTest/RandomGameTest.cs
+++ b/MyModTest/RandomGameTest.cs
@@ -5,8 +5,7 @@ using Handelabra.Sentinels.Engine.Model;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Troschuetz.Random;
-using Troschuetz.Random.Generators;
+using MathNet.Numerics.Random;
 using System.IO;
 
 namespace Handelabra.Sentinels.UnitTest
@@ -15,7 +14,7 @@ namespace Handelabra.Sentinels.UnitTest
     [TestFixture]
     public class RandomGameTest : BaseTest
     {
-        private IGenerator rng = new MT19937Generator();
+        private RandomSource rng = new MersenneTwister();
         private Random seededRng;
 
         protected IEnumerable<string> PreferredCardsToPlay = null;

--- a/MyModTest/packages.config
+++ b/MyModTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.12.0" targetFramework="net48" />
+  <package id="MathNet.Numerics" version="5.0.0" targetFramework="net48" />
+  <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.4.2" targetFramework="net48" />
-  <package id="Troschuetz.Random" version="5.0.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
`Troschuetz.Random` was deprecated. Their repo recommends upgrading to `MathNet.Numerics` (https://gitlab.com/pomma89/troschuetz-random). I made the change in my own project a while back and didn't encounter any problems with my tests.

Fortunately, the change appears very plug and play. :)