### PR TITLE
Base test improvements

### DIFF
--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -1054,8 +1054,15 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (this.DecisionSelectDamageType != null)
                     {
-                        damage.SelectedDamageType = this.DecisionSelectDamageType;
-                        Console.WriteLine("Selected: " + damage.SelectedDamageType);
+                        if (damage.Choices.Any(dt => dt == this.DecisionSelectDamageType))
+                        {
+                            damage.SelectedDamageType = this.DecisionSelectDamageType;
+                            Console.WriteLine("Selected: " + damage.SelectedDamageType);
+                        }
+                        else
+                        {
+                            Assert.Fail($"The selected damage type was not a choice: {this.DecisionSelectDamageType}");
+                        }
                     }
                     else
                     {

--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -3861,7 +3861,7 @@ namespace Handelabra.Sentinels.UnitTest
 
         protected void AssertOnTopOfDeck(TurnTakerController ttc, string identifier, int offset = 0)
         {
-            Assert.AreEqual(identifier, ttc.TurnTaker.Deck.TopCard.Identifier, "Expected " + identifier + " to be on top of " + ttc.Name + "'s deck.");
+            Assert.AreEqual(identifier, GetTopCardOfDeck(ttc, offset).Identifier, "Expected " + identifier + " to be on top of " + ttc.Name + "'s deck.");
         }
 
         protected void AssertOnBottomOfDeck(Card card, int offset = 0)

--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -683,13 +683,7 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (_numberOfChoicesInNextDecision != null)
                     {
-                        var check = true;
-                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
-                        {
-                            check = false;
-                        }
-
-                        if (check)
+                        if (_numberOfChoicesInNextDecisionSelectionType == null || _numberOfChoicesInNextDecisionSelectionType == decision.SelectionType)
                         {
                             Assert.AreEqual(_numberOfChoicesInNextDecision, selectCardDecision.Choices.Count(), "SelectCardDecision has the wrong number of choices.");
                             _numberOfChoicesInNextDecision = null;
@@ -1305,12 +1299,7 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (_numberOfChoicesInNextDecision != null)
                     {
-                        var check = true;
-                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
-                        {
-                            check = false;
-                        }
-                        if (check)
+                        if (_numberOfChoicesInNextDecisionSelectionType == null || _numberOfChoicesInNextDecisionSelectionType == decision.SelectionType)
                         {
                             Assert.AreEqual(_numberOfChoicesInNextDecision, selectTurnTaker.Choices.Count(), "SelectTurnTakerDecision has the wrong number of choices.");
                             _numberOfChoicesInNextDecision = null;
@@ -1376,13 +1365,7 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (_numberOfChoicesInNextDecision != null)
                     {
-                        var check = true;
-                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
-                        {
-                            check = false;
-                        }
-
-                        if (check)
+                        if (_numberOfChoicesInNextDecisionSelectionType == null || _numberOfChoicesInNextDecisionSelectionType == decision.SelectionType)
                         {
                             Assert.AreEqual(_numberOfChoicesInNextDecision, selectAction.Choices.Count(), "SelectFunctionDecision has the wrong number of choices.");
                             _numberOfChoicesInNextDecision = null;
@@ -1505,12 +1488,7 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (_numberOfChoicesInNextDecision != null)
                     {
-                        var check = true;
-                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
-                        {
-                            check = false;
-                        }
-                        if (check)
+                        if (_numberOfChoicesInNextDecisionSelectionType == null || _numberOfChoicesInNextDecisionSelectionType == decision.SelectionType)
                         {
                             Assert.AreEqual(_numberOfChoicesInNextDecision, selectWord.Choices.Count(), "SelectWordDecision has the wrong number of choices.");
                             _numberOfChoicesInNextDecision = null;

--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -1305,8 +1305,16 @@ namespace Handelabra.Sentinels.UnitTest
 
                     if (_numberOfChoicesInNextDecision != null)
                     {
-                        Assert.AreEqual(_numberOfChoicesInNextDecision, selectTurnTaker.Choices.Count(), "SelectTurnTakerDecision has the wrong number of choices.");
-                        _numberOfChoicesInNextDecision = null;
+                        var check = true;
+                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
+                        {
+                            check = false;
+                        }
+                        if (check)
+                        {
+                            Assert.AreEqual(_numberOfChoicesInNextDecision, selectTurnTaker.Choices.Count(), "SelectTurnTakerDecision has the wrong number of choices.");
+                            _numberOfChoicesInNextDecision = null;
+                        }
                     }
 
 
@@ -1494,6 +1502,20 @@ namespace Handelabra.Sentinels.UnitTest
                 {
                     SelectWordDecision selectWord = decision as SelectWordDecision;
                     Console.WriteLine("Make a SelectWordDecision: [" + selectWord.Choices.ToCommaList() + "]");
+
+                    if (_numberOfChoicesInNextDecision != null)
+                    {
+                        var check = true;
+                        if (_numberOfChoicesInNextDecisionSelectionType != null && _numberOfChoicesInNextDecisionSelectionType != decision.SelectionType)
+                        {
+                            check = false;
+                        }
+                        if (check)
+                        {
+                            Assert.AreEqual(_numberOfChoicesInNextDecision, selectWord.Choices.Count(), "SelectWordDecision has the wrong number of choices.");
+                            _numberOfChoicesInNextDecision = null;
+                        }
+                    }
 
                     if (this.DecisionSelectWords != null)
                     {


### PR DESCRIPTION
* When DecisionSelectDamageType is defined, make sure you're not giving an invalid choice (example: set to cold and use Absolution's power)
* When using AssertOnTopOfDeck, if offset is provided, use it (example: La Comadora's base power)
* Add/improve asserting the number of choices for SelectTurnTakerDecision and SelectWordDecision