### PR TITLE
Support mod cards in HandleGetHeroCardsInBoxRequest

### DIFF
--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -529,7 +529,7 @@ namespace Handelabra.Sentinels.UnitTest
             var modDefs = ModHelper.GetAllPromoDefinitions();
 
             // Find all the playable hero character cards in the box (including other sizes of Sky-Scraper)
-            var availableHeroes = DeckDefinition.AvailableHeroes.Union(GameController.Game.HeroTurnTakers.Select(tt => tt.DeckDefinition.QualifiedIdentifier)).Union(modDecks);
+            var availableHeroes = DeckDefinition.AvailableHeroes.Union(modDecks);
             foreach (var heroTurnTaker in availableHeroes.Where(turnTakerCriteria))
             {
                 var heroDefinition = DeckDefinitionCache.GetDeckDefinition(heroTurnTaker);

--- a/MyModTest/BaseTest.cs
+++ b/MyModTest/BaseTest.cs
@@ -517,7 +517,10 @@ namespace Handelabra.Sentinels.UnitTest
                     decklistName = decklistName.Remove(index);
                     decklistName = decklistName.Replace(".DeckLists", "");
 
-                    modDecks.Add(decklistName);
+                    string identifier;
+                    ModHelper.GetNamespaceFromQualifiedIdentifier(decklistName, out identifier);
+
+                    modDecks.Add($"{assembly.Key}.{identifier}");
                 }
             }
 


### PR DESCRIPTION
Currently the unit test HandleGetHeroCardsInBoxRequest does not allow getting either mod promo cards or mod hero decks. This patch fixes that. Promos supplied by a mod are extracted via `ModHelper.GetAllPromoDefinitions`. The rest of them are pulled in by using reflection to extract the registered assemblies from ModHelper, then iterating over the resources in the assembly.